### PR TITLE
Changed "if" statement formatting.

### DIFF
--- a/WordPress.xml
+++ b/WordPress.xml
@@ -74,7 +74,6 @@
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="CLASS_BRACE_STYLE" value="1" />
     <option name="METHOD_BRACE_STYLE" value="1" />
-    <option name="ELSE_ON_NEW_LINE" value="true" />
     <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
@@ -101,7 +100,7 @@
     <option name="ARRAY_INITIALIZER_WRAP" value="5" />
     <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
     <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
-    <option name="IF_BRACE_FORCE" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />


### PR DESCRIPTION
- Keep `else` on the same line as the braces.
- Force braces for if...else statements.

This automatically turns this (and other variations thereof):

``` php
// Boo!
if ( true ) return true;
else return false;
```

into this:

``` php
// Yea!
if ( true ) {
    return true;
} else {
    return false;
}
```

Previously it would end up one of these two ways:

``` php
// Not great.
if ( true ) {
    return true;
} 
else {
    return false;
}

// Horrid!
if ( true ) {
    return true;
} 
else return false;
```
