### PR TITLE
Missing space after unary

### DIFF
--- a/WordPress.xml
+++ b/WordPress.xml
@@ -30,6 +30,7 @@
     <option name="LOWER_CASE_NULL_CONST" value="true" />
     <option name="BLANK_LINE_BEFORE_RETURN_STATEMENT" value="true" />
     <option name="KEEP_RPAREN_AND_LBRACE_ON_ONE_LINE" value="true" />
+    <option name="SPACE_AFTER_UNARY_NOT" value="true" />
   </PHPCodeStyleSettings>
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />


### PR DESCRIPTION
WordPress coding standards require a space after ! 
```if ( ! $foo ) { ...```