### PR TITLE
Explicitly set indent size for SCSS

### DIFF
--- a/WordPress.xml
+++ b/WordPress.xml
@@ -275,6 +275,7 @@
   </codeStyleSettings>
   <codeStyleSettings language="SCSS">
     <indentOptions>
+      <option name="INDENT_SIZE" value="4" />      
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
       <option name="USE_TAB_CHARACTER" value="true" />
     </indentOptions>


### PR DESCRIPTION
This addition ensures the correct indentations are used for SCSS as WordPress's CSS code style. If unspecified, the indent can appear as something else. I reloaded the WordPress config several times and it loads up the indent size as 2 by default, until this was specified.
