### PR TITLE
Set right margin to 80

### DIFF
--- a/WordPress.xml
+++ b/WordPress.xml
@@ -13,6 +13,8 @@
       <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
+  <option name="RIGHT_MARGIN" value="80" />
+  <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
   <option name="HTML_ATTRIBUTE_WRAP" value="0" />
   <option name="HTML_TEXT_WRAP" value="0" />
   <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />


### PR DESCRIPTION
Re: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#spacing

I also found a setting in PhpStorm at Preferences > Editor > Code Style > Default Options > Right margin (columns) that can be set to `80`

The default is `120`

I tested `WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN` and it only applies to docblocks, not the actual code.